### PR TITLE
random untrimmed build jumpscare

### DIFF
--- a/sharp/Olympus.Sharp.csproj
+++ b/sharp/Olympus.Sharp.csproj
@@ -7,7 +7,7 @@
     <ApplicationIcon />
     <StartupObject />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PublishTrimmed>true</PublishTrimmed>
+    <PublishTrimmed>false</PublishTrimmed>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(RuntimeIdentifier.StartsWith('win'))">


### PR DESCRIPTION
triggers the pipeline for an untrimmed build because we aren't sure if trimming the build makes errors some people run into less clear